### PR TITLE
i18n double-curly brace deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ For example, if you want to localize your menu, define a new breadcrumbs node in
       breadcrumbs:
         homepage: Homepage
         profile: Your Profile
-        profile_dynamic: Hi {{name}}
+        profile_dynamic: Hi %{name}
 
     # config/locales/es.yml
     es:
       breadcrumbs:
         homepage: Homepage
         profile: Tu perfil
-        profile_dynamic: Hola {{name}}
+        profile_dynamic: Hola %{name}
 
 Then you can define the title of your crum as:
 


### PR DESCRIPTION
Hey Mathias,

I pushed a patch to the README, but didn't run the tests b/c the gem isn't using Bundler and "rake spec" doesn't work out of the box.

You'll probably have a failing spec on breadcrumbs_helper_spec line 58:

```
I18n.backend.store_translations(:en, {:breadcrumbs => {:profile => "Your Profile - {{login}}"}})
```

It should probably be:

```
I18n.backend.store_translations(:en, {:breadcrumbs => {:profile => "Your Profile - %{login}"}})
```

Hope that helps!

Shay
