### PR TITLE
Rails 2.3.14 and ruby 1.9.2 will produce invalid URL

### DIFF
--- a/app/helpers/breadcrumbs_helper.rb
+++ b/app/helpers/breadcrumbs_helper.rb
@@ -71,7 +71,7 @@ module BreadcrumbsHelper
       end
     when Hash
       params_hash.each do |pram, nested|
-        parameters[pram] = fetch_parameters_recursive(nested, params[pram])
+        parameters[pram] = fetch_parameters_recursive(nested, params[pram]) unless ! parameters[pram].present?
       end
     end
     parameters


### PR DESCRIPTION
...:action => something}) would result in an invalid URL

This is a quick fix that "works for me". The problem was that:

   { :action => "" } 
will result in appending {} to the URL, e.g

/home/%7B%7D 
with ruby 1.9.2

in 1.8.7 it is correctly

/home/

The fix will ignore empty values for any keys passed in through the params hash.
